### PR TITLE
Replace \thebibitem with \item

### DIFF
--- a/mla.cbx
+++ b/mla.cbx
@@ -766,9 +766,9 @@
        {\printnames{author}%
         \savefield{namehash}{\cbx@lasthash}}}
     {\let\cbx@lasthash\undefined}}
-\begin{thebibliography}\thebibitem}
+\begin{thebibliography}\item}
   {\usedriver{}{\thefield{entrytype}}\addperiod}
-  {\thebibitem}
+  {\item}
   {\end{thebibliography}\citereset}
 %\end{nothing}
 


### PR DESCRIPTION
LaTeX seems to choke on \thebibitem in \fullcite command -- replacing with just \item gets the desired behavior.
