### PR TITLE
Fix issue with series duplicated in biblography

### DIFF
--- a/mla.bbx
+++ b/mla.bbx
@@ -1199,7 +1199,7 @@
         }%
         {}%-keep-blank
       \newunit%
-      \usebibmacro{series+number}}%
+      }%
       \newunit%
       \usebibmacro{mla:reprint}%
     {}%-keep-blank


### PR DESCRIPTION
`series+number` macro was being called twice for many entry types, causing duplication in the works cited when a "series" property was defined. It looks like the command needs to be removed from the `publimedium` macro.