### PR TITLE
Fixed translated/reprint logic to work for biblatex 3.8+

### DIFF
--- a/mla-new.bbx
+++ b/mla-new.bbx
@@ -445,7 +445,7 @@
 \newbibmacro*{mla:reprint}{%
   \iffieldundef{origtitle}%
     {\newunit}%
-    {\iffieldundef{origlanguage}
+    {\iflistundef{origlanguage}
       {\setunit{\newunitpunct\bibstring{reprintof}\addspace}}%
       {\setunit{\newunitpunct\bibstring{transof}\addspace}}%
 }%

--- a/mla.bbx
+++ b/mla.bbx
@@ -433,7 +433,7 @@
 \newbibmacro*{mla:reprint}{%
   \iffieldundef{origtitle}%
     {\newunit}%
-    {\iffieldundef{origlanguage}
+    {\iflistundef{origlanguage}
       {\setunit{\newunitpunct\bibstring{reprintof}\addspace}}%
       {\setunit{\newunitpunct\bibstring{transof}\addspace}}%
 }%


### PR DESCRIPTION
As pointed out by moewew in https://github.com/jmclawson/biblatex-mla/issues/16, this logic is now broken. Have tested on biblatex 3.11

Would be great to get this and any other fixes pushed into a new release please.