### PR TITLE
Correcting a typo?!

### DIFF
--- a/mla7.bbx
+++ b/mla7.bbx
@@ -1217,9 +1217,9 @@
         }%
         {}%-keep-blank
       \newunit%
-      \usebibmacro{series+number}}%
+      \usebibmacro{series+number}%
       \newunit%
-      \usebibmacro{mla:reprint}%
+      \usebibmacro{mla:reprint}}%
     {}%-keep-blank
 }
 


### PR DESCRIPTION
Hi!
During a disscussion (see https://github.com/michal-h21/biblatex-iso690/issues/116) of the biblatex iso 690 style which I contribute to, @moewew pointed me to your style so that I had a quick glance at it.

Maybe I am not yet good enough with all the biblatex stuff and I don't understand your code correctly, but it looks strange to me that there is some code right after the `true` case of `\ifbool{bbx@publimedium}` is finished, but before the empty `false` case with `{}%-keep-blank` starts...